### PR TITLE
Fixed incorrect map key when parsing alert-rule target tags values

### DIFF
--- a/prismacloud/resource_alert_rule.go
+++ b/prismacloud/resource_alert_rule.go
@@ -360,7 +360,7 @@ func parseAlertRule(d *schema.ResourceData, id string) rule.Rule {
 			tmap := item.(map[string]interface{})
 			tags = append(tags, rule.Tag{
 				Key:    tmap["key"].(string),
-				Values: ListToStringSlice(tmap["key"].([]interface{})),
+				Values: ListToStringSlice(tmap["values"].([]interface{})),
 			})
 		}
 	}

--- a/prismacloud/resource_alert_rule_test.go
+++ b/prismacloud/resource_alert_rule_test.go
@@ -17,6 +17,17 @@ func TestAccAlertRule(t *testing.T) {
 	grp := fmt.Sprintf("tf%s", acctest.RandString(6))
 	name := fmt.Sprintf("tf%s", acctest.RandString(6))
 
+	tags := []rule.Tag{
+		{
+			Key:    fmt.Sprintf("tf%s", acctest.RandString(6)),
+			Values: []string{fmt.Sprintf("tf%s", acctest.RandString(6)), fmt.Sprintf("tf%s", acctest.RandString(6))},
+		},
+		{
+			Key:    fmt.Sprintf("tf%s", acctest.RandString(6)),
+			Values: []string{fmt.Sprintf("tf%s", acctest.RandString(6)), fmt.Sprintf("tf%s", acctest.RandString(6))},
+		},
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -26,14 +37,21 @@ func TestAccAlertRule(t *testing.T) {
 				Config: testAccAlertRuleConfig(grp, name, "alert rule desc1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlertRuleExists("prismacloud_alert_rule.test", &o),
-					testAccCheckAlertRuleAttributes(&o, name, "alert rule desc1"),
+					testAccCheckAlertRuleAttributes(&o, name, "alert rule desc1", nil),
 				),
 			},
 			{
 				Config: testAccAlertRuleConfig(grp, name, "alert rule desc2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAlertRuleExists("prismacloud_alert_rule.test", &o),
-					testAccCheckAlertRuleAttributes(&o, name, "alert rule desc2"),
+					testAccCheckAlertRuleAttributes(&o, name, "alert rule desc2", nil),
+				),
+			},
+			{
+				Config: testAccAlertRuleConfigTags(grp, name, "alert rule tags", tags),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAlertRuleExists("prismacloud_alert_rule.test", &o),
+					testAccCheckAlertRuleAttributes(&o, name, "alert rule with tags", tags),
 				),
 			},
 		},
@@ -64,7 +82,7 @@ func testAccCheckAlertRuleExists(n string, o *rule.Rule) resource.TestCheckFunc 
 	}
 }
 
-func testAccCheckAlertRuleAttributes(o *rule.Rule, name, desc string) resource.TestCheckFunc {
+func testAccCheckAlertRuleAttributes(o *rule.Rule, name, desc string, tags []rule.Tag) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if o.Name != name {
 			return fmt.Errorf("Name is %s, expected %s", o.Name, name)
@@ -72,6 +90,21 @@ func testAccCheckAlertRuleAttributes(o *rule.Rule, name, desc string) resource.T
 
 		if o.Description != desc {
 			return fmt.Errorf("Description is %s, expected %s", o.Description, desc)
+		}
+
+		if tags != nil {
+			for i := 0; i < len(tags); i++ {
+				if o.Target.Tags[i].Key != tags[i].Key {
+					return fmt.Errorf("Tags is %+v, expected %+v", o.Target.Tags, tags)
+				}
+
+				for j := 0; j < len(tags[i].Values); j++ {
+					if o.Target.Tags[i].Values[j] != tags[i].Values[j] {
+						return fmt.Errorf("Tags is %+v, expected %+v", o.Target.Tags, tags)
+					}
+				}
+			}
+
 		}
 
 		return nil
@@ -117,4 +150,34 @@ resource "prismacloud_alert_rule" "test" {
     }
 }
 `, grp, name, desc)
+}
+
+func testAccAlertRuleConfigTags(grp, name, desc string, tags []rule.Tag) string {
+	return fmt.Sprintf(`
+	resource "prismacloud_account_group" "x" {
+		name = %q
+		description = "for alert rule acctest"
+	}
+	
+	resource "prismacloud_alert_rule" "test" {
+		name = %q
+		description = %q
+		enabled = false
+		scan_all = true
+		target {
+			account_groups = [
+				prismacloud_account_group.x.group_id,
+			]
+			tags {
+				key = "%s"
+				values = ["%s", "%s"]
+			}
+
+			tags {
+				key = "%s"
+				values = ["%s", "%s"]
+			}
+		}
+	}
+	`, grp, name, desc, tags[0].Key, tags[0].Values[0], tags[0].Values[1], tags[1].Key, tags[1].Values[0], tags[1].Values[1])
 }


### PR DESCRIPTION
## Description

Fixed incorrect map key when parsing alert-rule target tag values.
Resloves #21 

## Motivation and Context

The tag values were incorrectly set to the key, which gave an error when trying to cast the key to a slice of interfaces:
```
tags = append(tags, rule.Tag{
	Key:    tmap["key"].(string),
	Values: ListToStringSlice(tmap["key"].([]interface{})),     // <- should be tmap["values"]
})
```


## How Has This Been Tested?
I added a test to verify that the tags work (see second commit). Additionally, there is one line changed, so I verified it manually by building the provider and testing that the alert-rule now succeeds when specifying tags:
```
  # prismacloud_alert_rule.main will be created
  + resource "prismacloud_alert_rule" "main" {
      + enabled               = true
      + id                    = (known after apply)
      + last_modified_by      = (known after apply)
      + last_modified_on      = (known after apply)
      + name                  = "Terraform-test-alerts"
      + notification_channels = (known after apply)
      + notify_on_open        = true
      + open_alerts_count     = (known after apply)
      + owner                 = (known after apply)
      + policies              = [
          + <removed>,
        ]
      + policy_labels         = []
      + policy_scan_config_id = (known after apply)
      + read_only             = (known after apply)
      + scan_all              = true

      + notification_config {
          + config_type     = "email"
          + enabled         = true
          + last_sent_ts    = (known after apply)
          + last_updated    = (known after apply)
          + r_rule_schedule = "FREQ=WEEKLY;BYDAY=MO;INTERVAL=1"
          + recipients      = [
              + <removed>,
            ]
          + template_id     = <removed>
          + timezone_id     = "Europe/Oslo"
        }

      + target {
          + account_groups = [
              + <removed>,
            ]

          + tags {
              + key    = "test"
              + values = [
                  + "test",
                ]
            }
        }
    }
```
Which resulted in:
```Apply complete! Resources: 1 added, 0 changed, 0 destroyed.```

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
