### PR TITLE
Adding an option to disable the account on terraform destroy and also an option to update the account on create

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,10 @@
 module github.com/terraform-providers/terraform-provider-prismacloud
+
 require (
-    github.com/hashicorp/terraform-plugin-sdk v1.9.0
-    github.com/paloaltonetworks/prisma-cloud-go v0.4.0
+   		github.com/hashicorp/terraform-plugin-sdk v1.9.0
+    	github.com/paloaltonetworks/prisma-cloud-go v0.4.0
 )
+
 replace github.com/paloaltonetworks/prisma-cloud-go => ../prisma-cloud-go
+
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/terraform-providers/terraform-provider-prismacloud
 
 require (
-   		github.com/hashicorp/terraform-plugin-sdk v1.9.0
-    	github.com/paloaltonetworks/prisma-cloud-go v0.4.0
+	github.com/hashicorp/terraform-plugin-sdk v1.9.0
+	github.com/paloaltonetworks/prisma-cloud-go v0.4.0
 )
 
-replace github.com/paloaltonetworks/prisma-cloud-go => ../prisma-cloud-go
+//replace github.com/paloaltonetworks/prisma-cloud-go => ../prisma-cloud-go
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/terraform-providers/terraform-provider-prismacloud
 
 require (
+	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk v1.9.0
 	github.com/paloaltonetworks/prisma-cloud-go v0.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,7 @@
 module github.com/terraform-providers/terraform-provider-prismacloud
-
 require (
-	github.com/hashicorp/terraform-plugin-sdk v1.9.0
-	github.com/paloaltonetworks/prisma-cloud-go v0.4.0
+    github.com/hashicorp/terraform-plugin-sdk v1.9.0
+    github.com/paloaltonetworks/prisma-cloud-go v0.4.0
 )
-
-//replace github.com/paloaltonetworks/prisma-cloud-go => ../prisma-cloud-go
-
+replace github.com/paloaltonetworks/prisma-cloud-go => ../prisma-cloud-go
 go 1.13

--- a/prismacloud/resource_cloud_account.go
+++ b/prismacloud/resource_cloud_account.go
@@ -506,7 +506,6 @@ func saveCloudAccount(d *schema.ResourceData, dest string, obj interface{}) {
 }
 
 func createCloudAccount(d *schema.ResourceData, meta interface{}) error {
-	log.Printf(" create is called")
 	azurekey := ResourceDataInterfaceMap(d, account.TypeAzure)["key"].(string)
 	log.Printf("azure key %d", azurekey)
 	client := meta.(*pc.Client)

--- a/prismacloud/resource_cloud_account.go
+++ b/prismacloud/resource_cloud_account.go
@@ -375,7 +375,6 @@ func gcpCredentialsMatch(k, old, new string, d *schema.ResourceData) bool {
 
 func parseCloudAccount(d *schema.ResourceData) (string, string, interface{}) {
 	if x := ResourceDataInterfaceMap(d, account.TypeAws); len(x) != 0 {
-
 		return account.TypeAws, x["name"].(string), account.Aws{
 			AccountId:      x["account_id"].(string),
 			Enabled:        x["enabled"].(bool),
@@ -463,10 +462,8 @@ func saveCloudAccount(d *schema.ResourceData, dest string, obj interface{}) {
 		}
 		val["disable_on_destroy"] = ResourceDataInterfaceMap(d, account.TypeAzure)["disable_on_destroy"]
 		val["update_on_create"] = ResourceDataInterfaceMap(d, account.TypeAzure)["update_on_create"]
-
 	case account.Gcp:
 		b, _ := json.Marshal(v.Credentials)
-		log.Printf("gcp in parse")
 		val = map[string]interface{}{
 			"account_id":               v.Account.AccountId,
 			"enabled":                  v.Account.Enabled,
@@ -506,8 +503,6 @@ func saveCloudAccount(d *schema.ResourceData, dest string, obj interface{}) {
 }
 
 func createCloudAccount(d *schema.ResourceData, meta interface{}) error {
-	azurekey := ResourceDataInterfaceMap(d, account.TypeAzure)["key"].(string)
-	log.Printf("azure key %d", azurekey)
 	client := meta.(*pc.Client)
 	cloudType, name, obj := parseCloudAccount(d)
 	updateIfExists := true
@@ -565,7 +560,6 @@ func createCloudAccount(d *schema.ResourceData, meta interface{}) error {
 }
 
 func readCloudAccount(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("read is called")
 	client := meta.(*pc.Client)
 	cloudType, id := IdToTwoStrings(d.Id())
 	obj, err := account.Get(client, cloudType, id)
@@ -583,15 +577,11 @@ func readCloudAccount(d *schema.ResourceData, meta interface{}) error {
 }
 
 func updateCloudAccount(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("update is called")
-	azurekey := ResourceDataInterfaceMap(d, account.TypeAzure)["key"].(string)
-	log.Printf("azure key %d", azurekey)
 	client := meta.(*pc.Client)
 	_, _, obj := parseCloudAccount(d)
 	if err := account.Update(client, obj); err != nil {
 		return err
 	}
-	log.Printf("update is done")
 	return readCloudAccount(d, meta)
 }
 
@@ -649,7 +639,5 @@ func deleteCloudAccount(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	d.SetId("")
-	return nil
-
 	return nil
 }

--- a/prismacloud/resource_cloud_account.go
+++ b/prismacloud/resource_cloud_account.go
@@ -404,6 +404,7 @@ func parseCloudAccount(d *schema.ResourceData) (string, string, interface{}) {
 	} else if x := ResourceDataInterfaceMap(d, account.TypeGcp); len(x) != 0 {
 		var creds account.GcpCredentials
 		_ = json.Unmarshal([]byte(x["credentials_json"].(string)), &creds)
+		
 		return account.TypeGcp, x["name"].(string), account.Gcp{
 			Account: account.CloudAccount{
 				AccountId:      x["account_id"].(string),
@@ -427,11 +428,13 @@ func parseCloudAccount(d *schema.ResourceData) (string, string, interface{}) {
 			Enabled:   x["enabled"].(bool),
 		}
 	}
+
 	return "", "", nil
 }
 
 func saveCloudAccount(d *schema.ResourceData, dest string, obj interface{}) {
 	var val map[string]interface{}
+
 	switch v := obj.(type) {
 	case account.Aws:
 		val = map[string]interface{}{
@@ -562,6 +565,7 @@ func createCloudAccount(d *schema.ResourceData, meta interface{}) error {
 func readCloudAccount(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*pc.Client)
 	cloudType, id := IdToTwoStrings(d.Id())
+
 	obj, err := account.Get(client, cloudType, id)
 	if err != nil {
 		if err == pc.ObjectNotFoundError {
@@ -578,10 +582,13 @@ func readCloudAccount(d *schema.ResourceData, meta interface{}) error {
 
 func updateCloudAccount(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*pc.Client)
+
 	_, _, obj := parseCloudAccount(d)
+
 	if err := account.Update(client, obj); err != nil {
 		return err
 	}
+
 	return readCloudAccount(d, meta)
 }
 
@@ -638,6 +645,7 @@ func deleteCloudAccount(d *schema.ResourceData, meta interface{}) error {
 			return err
 		}
 	}
+
 	d.SetId("")
 	return nil
 }

--- a/prismacloud/resource_cloud_account.go
+++ b/prismacloud/resource_cloud_account.go
@@ -3,6 +3,7 @@ package prismacloud
 import (
 	"encoding/json"
 	"log"
+	"strings"
 	"time"
 
 	pc "github.com/paloaltonetworks/prisma-cloud-go"
@@ -92,7 +93,7 @@ func resourceCloudAccount() *schema.Resource {
 						"disable_on_destroy": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "To off-board an account",
+							Description: "To disable the account on terraform destroy",
 							Default: false,
 						},
 					},
@@ -178,7 +179,7 @@ func resourceCloudAccount() *schema.Resource {
 						"disable_on_destroy": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "To off-board an account",
+							Description: "To disable the account on terraform destroy",
 							Default: false,
 						},
 					},
@@ -261,7 +262,7 @@ func resourceCloudAccount() *schema.Resource {
 						"disable_on_destroy": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "To off-board an account",
+							Description: "To disable the account on terraform destroy",
 							Default: false,
 						},
 					},
@@ -313,7 +314,7 @@ func resourceCloudAccount() *schema.Resource {
 						"disable_on_destroy": {
 							Type:        schema.TypeBool,
 							Optional:    true,
-							Description: "To off-board an account",
+							Description: "To disable the account on terraform destroy",
 							Default: false,
 						},
 					},
@@ -481,27 +482,8 @@ func createCloudAccount(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*pc.Client)
 	cloudType, name, obj := parseCloudAccount(d)
 
-	cloudaccountType := ""
-	switch cloudType {
-	case account.TypeAws:
-		cloudaccountType = "aws"
-	case account.TypeAzure:
-		cloudaccountType = "azure"
-	case account.TypeGcp:
-		cloudaccountType = "gcp"
-	case account.TypeAlibaba:
-		cloudaccountType = "alibaba_cloud"
-	}
-
-	duplicateError := pc.PrismaCloudErrorList{
-		Errors: []pc.PrismaCloudError{{Message:  "duplicate_cloud_account", Severity: "error", Subject:  ""}},
-		Method:     "POST",
-		StatusCode: 400,
-		Path:       "https://"  +client.Url + "/cloud/" + cloudaccountType,
-	}
-
 	if err := account.Create(client, obj); err != nil {
-		if err.Error() == duplicateError.Error() {
+		if strings.Contains(err.Error(),"duplicate_cloud_account" ){
 			if err := account.Update(client, obj); err != nil {
 				return err
 			}


### PR DESCRIPTION
On terraform destroy now it can disable the prismacloud_cloud_account if disable_on_destroy is true.
Also createcloudaccount function enables the disabled prismacloud_cloud_account instead of throwing duplicate error.