### PR TITLE
Fix cloud account group IDs not maintaining order

### DIFF
--- a/prismacloud/resource_cloud_account.go
+++ b/prismacloud/resource_cloud_account.go
@@ -35,7 +35,7 @@ func resourceCloudAccount() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Description: "to disable cloud account instead of deleting on calling destroy",
-				Default: false,
+				Default:     false,
 			},
 
 			// AWS type.
@@ -69,7 +69,7 @@ func resourceCloudAccount() *schema.Resource {
 							Sensitive:   true,
 						},
 						"group_ids": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Required:    true,
 							Description: "List of account IDs to which you are assigning this account",
 							Elem: &schema.Schema{
@@ -127,7 +127,7 @@ func resourceCloudAccount() *schema.Resource {
 							Default:     true,
 						},
 						"group_ids": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Required:    true,
 							Description: "List of account IDs to which you are assigning this account",
 							Elem: &schema.Schema{
@@ -207,7 +207,7 @@ func resourceCloudAccount() *schema.Resource {
 							Default:     true,
 						},
 						"group_ids": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Required:    true,
 							Description: "List of account IDs to which you are assigning this account",
 							Elem: &schema.Schema{
@@ -278,7 +278,7 @@ func resourceCloudAccount() *schema.Resource {
 							Description: "Alibaba account ID",
 						},
 						"group_ids": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Required:    true,
 							Description: "List of account IDs to which you are assigning this account",
 							Elem: &schema.Schema{


### PR DESCRIPTION
## Description

Change schema type of cloud account group IDs from `schema.TypeList` to `schema.TypeSet` to ensure that a consistent ordering is kept (and ensure duplicates are not allowed).

## Motivation and Context

Fixes #48 #49 

## How Has This Been Tested?
After applying the fix, I was not prompted for a change during a plan operation when testing locally.

## Screenshots (if appropriate)

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
