### PR TITLE
Adding changes to avoid diff on every terraform plan for reports

### DIFF
--- a/prismacloud/resource_report.go
+++ b/prismacloud/resource_report.go
@@ -233,7 +233,7 @@ func parseReport(d *schema.ResourceData, id string) report.Report {
 	}
 
 	var accounts []string
-	if accs := tgt["excluded_accounts"]; accs != nil {
+	if accs := tgt["accounts"]; accs != nil {
 		accounts = SetToStringSlice(accs.(*schema.Set))
 	}
 
@@ -300,6 +300,9 @@ func saveReport(d *schema.ResourceData, obj report.Report) {
 	d.Set("last_scheduled", obj.LastScheduled)
 	d.Set("total_instance_count", obj.TotalInstanceCount)
 
+	trgt := ResourceDataInterfaceMap(d, "target")
+	tr := trgt["time_range"].([]interface{})
+
 	// Target.
 	tgt := map[string]interface{}{
 		"account_groups":           obj.Target.AccountGroups,
@@ -313,7 +316,7 @@ func saveReport(d *schema.ResourceData, obj report.Report) {
 		"schedule":                 obj.Target.Schedule,
 		"schedule_enabled":         obj.Target.ScheduleEnabled,
 		"notification_template_id": obj.Target.NotificationTemplateId,
-		"time_range":               flattenTimeRange(obj.Target.TimeRange),
+		"time_range":               tr,
 	}
 
 	if err := d.Set("target", []interface{}{tgt}); err != nil {


### PR DESCRIPTION
- Adding these changes to ensure that terraform plan should't detect any diff for reports if there is no change in tf script
- Diff is detected due to timerange as API changes all timerange types (absolute, relative and to_now) to absolute in response body