### PR TITLE
Changing compliance metadata parameters to computed to avoid diff on every terraform plan

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -67,12 +67,7 @@ This section may be present or may be omitted:
 
 ### Compliance Metadata
 
-* `requirement_id` - Requirement ID
-* `requirement_description` - Requirement description
-* `section_id` - Section ID
 * `compliance_id` - (Required) Compliance Section UUID
-* `section_label` - Section label
-* `custom_assigned` - (bool) Custom assigned
 
 #### Data Criteria
 
@@ -102,8 +97,13 @@ In each `Compliance Metadata` section, the following attributes are available:
 * `standard_name` - Compliance standard name
 * `standard_description` - Compliance standard description
 * `requirement_name` - Requirement name
+* `requirement_id` - Requirement ID
+* `requirement_description` - Requirement description
 * `section_description` - Section description
+* `section_id` - Section ID
+* `section_label` - Section label
 * `policy_id` - Policy ID
+* `custom_assigned` - (bool) Custom assigned
 
 ## Import
 

--- a/prismacloud/resource_policy.go
+++ b/prismacloud/resource_policy.go
@@ -348,7 +348,7 @@ func resourcePolicy() *schema.Resource {
 						},
 						"requirement_id": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Requirement ID",
 						},
 						"requirement_name": {
@@ -358,12 +358,12 @@ func resourcePolicy() *schema.Resource {
 						},
 						"requirement_description": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Requirement description",
 						},
 						"section_id": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Section ID",
 						},
 						"section_description": {
@@ -383,12 +383,12 @@ func resourcePolicy() *schema.Resource {
 						},
 						"section_label": {
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true,
 							Description: "Section label",
 						},
 						"custom_assigned": {
 							Type:        schema.TypeBool,
-							Optional:    true,
+							Computed:    true,
 							Description: "Custom assigned",
 						},
 					},
@@ -461,13 +461,7 @@ func parsePolicy(d *schema.ResourceData, id string) policy.Policy {
 	for _, csmi := range cms {
 		cmd := csmi.(map[string]interface{})
 		ans.ComplianceMetadata = append(ans.ComplianceMetadata, policy.ComplianceMetadata{
-			RequirementId:          cmd["requirement_id"].(string),
-			RequirementDescription: cmd["requirement_description"].(string),
-			SectionId:              cmd["section_id"].(string),
-			PolicyId:               id,
-			ComplianceId:           cmd["compliance_id"].(string),
-			SectionLabel:           cmd["section_label"].(string),
-			CustomAssigned:         cmd["custom_assigned"].(bool),
+			ComplianceId: cmd["compliance_id"].(string),
 		})
 	}
 


### PR DESCRIPTION
- Except compliance_id (Compliance section UUID) all other parameters in Compliance Metadata are read-only parameters so made them as computed
- This PR fixes the issue in this ticket [PCSUP-6674](https://redlock.atlassian.net/browse/PCSUP-6674)