### PR TITLE
Adding ForceNew field to timerange parameters for resource_saved_search

### DIFF
--- a/prismacloud/schema.go
+++ b/prismacloud/schema.go
@@ -133,6 +133,15 @@ func timeRangeSchema(style string) *schema.Schema {
 		to_now_resource.Schema["unit"].ValidateFunc = nil
 	case "resource_saved_search":
 		ans.ForceNew = true
+
+		absolute_resource.Schema["start"].ForceNew = true
+		absolute_resource.Schema["end"].ForceNew = true
+
+		relative_resource.Schema["amount"].ForceNew = true
+		relative_resource.Schema["unit"].ForceNew = true
+
+		to_now_resource.Schema["unit"].ForceNew = true
+
 		fallthrough
 	default:
 		ans.Optional = true


### PR DESCRIPTION
ForceNew is added to trigger the deletion of existing saved search and creating a new one based on updated rql_search