### PR TITLE
Making associated_users as computed parameter in user_role resource to fix issue #94

### DIFF
--- a/docs/resources/user_role.md
+++ b/docs/resources/user_role.md
@@ -22,7 +22,6 @@ resource "prismacloud_user_role" "example" {
 * `description` - (Optional) Description.
 * `role_type` - (Required) User role type.  Valid valies are `System Admin`, `Account Group Admin`, `Account Group Read Only`, `Cloud Provisioning Admin`, or `Account and Cloud Provisioning Admin`.
 * `account_group_ids` - (Optional) List of accessible account group IDs.
-* `associated_users` - (Optional) List of associated application users which cannot exist in the system without the user role.
 * `restrict_dismissal_access` - (Optional, bool) Restrict dismissal access.
 * `additional_attributes` - (Optional) An Additional attributesspec, as defined [below](#Additional Attributes).
 
@@ -38,6 +37,7 @@ resource "prismacloud_user_role" "example" {
 * `role_id` - Role UUID.
 * `last_modified_by` - Last modified by
 * `last_modified_ts` - (int) Last modified timestamp.
+* `associated_users` - List of associated application users which cannot exist in the system without the user role.
 * `account_groups` - List of account groups, as defined [below](#account-groups).
 
 ### Account Groups

--- a/prismacloud/resource_user_role.go
+++ b/prismacloud/resource_user_role.go
@@ -73,7 +73,7 @@ func resourceUserRole() *schema.Resource {
 			},
 			"associated_users": {
 				Type:        schema.TypeSet,
-				Optional:    true,
+				Computed:    true,
 				Description: "Associated application users which cannot exist in the system without the user role",
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
@@ -145,7 +145,6 @@ func parseUserRole(d *schema.ResourceData) *role.Role {
 		Description:             d.Get("description").(string),
 		RoleType:                d.Get("role_type").(string),
 		AccountGroupIds:         SetToStringSlice(d.Get("account_group_ids").(*schema.Set)),
-		AssociatedUsers:         SetToStringSlice(d.Get("associated_users").(*schema.Set)),
 		RestrictDismissalAccess: d.Get("restrict_dismissal_access").(bool),
 	}
 


### PR DESCRIPTION
- associated_users is read-only parameter for user role, users can't be added while adding user role