### PR TITLE
Removing comparison of gcp private key to avoid diff on every terraform plan

### DIFF
--- a/prismacloud/resource_cloud_account.go
+++ b/prismacloud/resource_cloud_account.go
@@ -325,7 +325,7 @@ func gcpCredentialsMatch(k, old, new string, d *schema.ResourceData) bool {
 	return (prev.Type == cur.Type &&
 		prev.ProjectId == cur.ProjectId &&
 		prev.PrivateKeyId == cur.PrivateKeyId &&
-		prev.PrivateKey == cur.PrivateKey &&
+		//prev.PrivateKey == cur.PrivateKey &&       //Commenting this comparison of privateKey to avoid diff on every terraform plan
 		prev.ClientEmail == cur.ClientEmail &&
 		prev.ClientId == cur.ClientId &&
 		prev.AuthUri == cur.AuthUri &&


### PR DESCRIPTION
- Removing comparison of gcp private key to avoid diff on every terraform plan when no changes are made to tf script
- This won't affect when private key is changed as private key will change along with private key id and we have comparison for private key id
