### PR TITLE
Adding changes to store azure key in tfstate to avoid diff in every terraform plan

### DIFF
--- a/docs/resources/cloud_account.md
+++ b/docs/resources/cloud_account.md
@@ -79,7 +79,6 @@ The type of cloud account to add.  You need to specify one and only one of these
 
 ### Azure
 
-!> The Prisma Cloud API returns a series of asterisks for the `key` field instead of the configured value.  Because of this, the provider cannot detect configuration drift on the `key` param.
 
 * `account_id` - (Required) Azure account ID.
 * `enabled` - (Optional, bool) Whether or not the account is enabled (defualt: `true`).

--- a/prismacloud/resource_cloud_account.go
+++ b/prismacloud/resource_cloud_account.go
@@ -149,9 +149,6 @@ func resourceCloudAccount() *schema.Resource {
 							Required:    true,
 							Description: "Application ID key",
 							Sensitive:   true,
-							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-								return true
-							},
 						},
 						"monitor_flow_logs": {
 							Type:        schema.TypeBool,
@@ -412,13 +409,14 @@ func saveCloudAccount(d *schema.ResourceData, dest string, obj interface{}) {
 			"account_type":    v.AccountType,
 		}
 	case account.Azure:
+		x := ResourceDataInterfaceMap(d, account.TypeAzure)
 		val = map[string]interface{}{
 			"account_id":           v.Account.AccountId,
 			"enabled":              v.Account.Enabled,
 			"group_ids":            v.Account.GroupIds,
 			"name":                 v.Account.Name,
 			"client_id":            v.ClientId,
-			"key":                  v.Key,
+			"key":                  x["key"].(string),
 			"monitor_flow_logs":    v.MonitorFlowLogs,
 			"tenant_id":            v.TenantId,
 			"service_principal_id": v.ServicePrincipalId,

--- a/prismacloud/resource_org_cloud_account.go
+++ b/prismacloud/resource_org_cloud_account.go
@@ -590,6 +590,7 @@ func saveOrgCloudAccount(d *schema.ResourceData, dest string, obj interface{}) {
 			"user_ocid":                v.UserOcid,
 		}
 	case org.AzureOrg:
+		x := ResourceDataInterfaceMap(d, org.TypeAzureOrg)
 		val = map[string]interface{}{
 			"account_id":           v.Account.AccountId,
 			"enabled":              v.Account.Enabled,
@@ -601,7 +602,7 @@ func saveOrgCloudAccount(d *schema.ResourceData, dest string, obj interface{}) {
 			"tenant_id":            v.TenantId,
 			"service_principal_id": v.ServicePrincipalId,
 			"monitor_flow_logs":    v.MonitorFlowLogs,
-			"key":                  v.Key,
+			"key":                  x["key"].(string),
 		}
 	case org.GcpOrg:
 		b, _ := json.Marshal(v.Credentials)


### PR DESCRIPTION
- These changes will store the actual value of azure key in tf state instead of storing in asterisks form
- Now since tf state file will contain the actual credentials, it's important to keep the state file secured