### PR TITLE
Include Jira as an Alert Notification Config type

### DIFF
--- a/docs/resources/alert_rule.md
+++ b/docs/resources/alert_rule.md
@@ -55,7 +55,7 @@ There should be one and only one target block:
 * `detailed_report` - (bool) Provide CSV detailed report
 * `with_compression` - (bool) Compress detailed report
 * `include_remediation` - (bool) Include remediation in detailed report
-* `config_type` - Config type.  Valid values are `email`, `slack`, `splunk`, `amazon_sqs`, `microsoft_teams`, `webhook`, `aws_security_hub`, `google_cscc`, `service_now`, `pager_duty`, `aws_s3`, `snowflake`  or `demisto`
+* `config_type` - Config type.  Valid values are `email`, `slack`, `splunk`, `amazon_sqs`, `microsoft_teams`, `jira`, `webhook`, `aws_security_hub`, `google_cscc`, `service_now`, `pager_duty`, `aws_s3`, `snowflake` or `demisto`
 * `template_id` - Template ID
 * `r_rule_schedule` - R rule schedule
 

--- a/prismacloud/resource_alert_rule.go
+++ b/prismacloud/resource_alert_rule.go
@@ -267,6 +267,7 @@ func resourceAlertRule() *schema.Resource {
 									rule.TypeSplunk,
 									rule.TypeAmazonSqs,
 									rule.TypeMicrosoftTeams,
+									rule.TypeJira,
 									rule.TypeWebhook,
 									rule.TypeAwsSecurityHub,
 									rule.TypeGoogleCscc,


### PR DESCRIPTION
Jira is missing as a config type for alert rules.

Currently blocked by: https://github.com/PaloAltoNetworks/prisma-cloud-go/pull/24