### PR TITLE
Adding support for new integration API for outbound integrations

### DIFF
--- a/prismacloud/conversions.go
+++ b/prismacloud/conversions.go
@@ -125,3 +125,12 @@ func Base64Decode(v string) []string {
 
 	return strings.Split(string(joined), "\n")
 }
+
+func stringInSlice(str string, list []string) bool {
+	for _, s := range list {
+		if s == str {
+			return true
+		}
+	}
+	return false
+}

--- a/prismacloud/data_source_integration_test.go
+++ b/prismacloud/data_source_integration_test.go
@@ -30,12 +30,13 @@ func testAccDsIntegrationConfig(name string) string {
 	return fmt.Sprintf(`
 data "prismacloud_integration" "test" {
     integration_id = prismacloud_integration.x.integration_id
+	integration_type = "pager_duty"
 }
 
 resource "prismacloud_integration" "x" {
     name = %q
     description = "integration ds acctest"
-    enabled = false
+    enabled = true
     integration_type = "pager_duty"
     integration_config {
         integration_key = "mySecretKey"

--- a/prismacloud/data_source_integrations.go
+++ b/prismacloud/data_source_integrations.go
@@ -67,16 +67,22 @@ func dataSourceIntegrations() *schema.Resource {
 func dataSourceIntegrationsRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*pc.Client)
 
-	items, err := integration.List(client, "")
+	outboundIntegrations, err := integration.List(client, "", true)
 	if err != nil {
 		return err
 	}
 
-	d.SetId("integrations")
-	d.Set("total", len(items))
+	inboundIntegrations, err := integration.List(client, "", false)
+	if err != nil {
+		return err
+	}
 
-	listing := make([]interface{}, 0, len(items))
-	for _, o := range items {
+	allIntegrations := append(outboundIntegrations, inboundIntegrations...)
+	d.SetId("integrations")
+	d.Set("total", len(allIntegrations))
+
+	listing := make([]interface{}, 0, len(allIntegrations))
+	for _, o := range allIntegrations {
 		listing = append(listing, map[string]interface{}{
 			"integration_id":   o.Id,
 			"name":             o.Name,


### PR DESCRIPTION
- The integration APIs currently used by terraform-provider are deprecated for all integrations except okta, Qualys and Tenable.
- Changes in this PR will add support for new API exposed for the remaining integrations
