### PR TITLE
Adding support for access_key_max_validity and alarm_enabled parameters in enterprise_settings resource

### DIFF
--- a/docs/data-sources/enterprise_settings.md
+++ b/docs/data-sources/enterprise_settings.md
@@ -15,9 +15,9 @@ data "prismacloud_enterprise_settings" "example" {}
 ## Attribute Reference
 
 * `session_timeout` - (int) Browser session timeout.
-* `anomaly_training_model_threshold` - Anomaly training model threshold.
-* `anomaly_alert_disposition` - Anomaly alert disposition.
+* `access_key_max_validity` - (int) Access Keys maximum validity in days.
 * `user_attribution_in_notification` - (bool) User attribution in notification.
 * `require_alert_dismissal_note` - (bool) Require alert dismissal note.
 * `default_policies_enabled` - (Map of bools) Default policies enabled.
 * `apply_default_policies_enabled` - (bool) Apply default policies enabled.
+* `alarm_enabled` - (bool) Alarms enabled. Alarms are Prisma Cloud Platform health notifications which are generated to notify users of system level issues/errors.

--- a/docs/resources/enterprise_settings.md
+++ b/docs/resources/enterprise_settings.md
@@ -10,11 +10,12 @@ Manages enterprise settings config.
 
 ```hcl
 resource "prismacloud_enterprise_settings" "example" {
+    access_key_max_validity = 30
     session_timeout = 60
     default_policies_enabled = {
-        "high": True,
-        "medium": True,
-        "low": False,
+        "high": true,
+        "medium": true,
+        "low": false,
     }
 }
 ```
@@ -22,9 +23,9 @@ resource "prismacloud_enterprise_settings" "example" {
 ## Argument Reference
 
 * `session_timeout` - (int) Browser session timeout.
-* `anomaly_training_model_threshold` - Anomaly training model threshold (`low`, `medium`, or `high`).
-* `anomaly_alert_disposition` - Anomaly alert disposition (`low`, `medium`, or `high`).
+* `access_key_max_validity` - (int) Access Keys maximum validity in days.
 * `user_attribution_in_notification` - (bool) User attribution in notification.
 * `require_alert_dismissal_note` - (bool) Require alert dismissal note.
 * `default_policies_enabled` - (Map of bools) Default policies enabled.
 * `apply_default_policies_enabled` - (bool) Apply default policies enabled.
+* `alarm_enabled` - (bool) Alarms enabled (Default : `true`). Alarms are Prisma Cloud Platform health notifications which are generated to notify users of system level issues/errors. Disabling alarms will delete all existing alarms which were previously generated.

--- a/prismacloud/data_source_enterprise_settings.go
+++ b/prismacloud/data_source_enterprise_settings.go
@@ -10,20 +10,15 @@ func dataSourceEnterpriseSettings() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			// Output.
+			"access_key_max_validity": {
+				Type:        schema.TypeInt,
+				Computed:    true,
+				Description: "Access Keys maximum validity in days",
+			},
 			"session_timeout": {
 				Type:        schema.TypeInt,
 				Computed:    true,
 				Description: "Browser session timeout",
-			},
-			"anomaly_training_model_threshold": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Anomaly training model threshold",
-			},
-			"anomaly_alert_disposition": {
-				Type:        schema.TypeString,
-				Computed:    true,
-				Description: "Anomaly alert disposition",
 			},
 			"user_attribution_in_notification": {
 				Type:        schema.TypeBool,
@@ -47,6 +42,11 @@ func dataSourceEnterpriseSettings() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 				Description: "Apply default policies enabled",
+			},
+			"alarm_enabled": {
+				Type:        schema.TypeBool,
+				Computed:    true,
+				Description: "Alarms enabled",
 			},
 		},
 	}

--- a/prismacloud/data_source_enterprise_settings_test.go
+++ b/prismacloud/data_source_enterprise_settings_test.go
@@ -14,12 +14,12 @@ func TestAccDsEnterpriseSettings(t *testing.T) {
 			{
 				Config: testAccDsEnterpriseSettingsConfig(),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.prismacloud_enterprise_settings.test", "access_key_max_validity"),
 					resource.TestCheckResourceAttrSet("data.prismacloud_enterprise_settings.test", "session_timeout"),
-					resource.TestCheckResourceAttrSet("data.prismacloud_enterprise_settings.test", "anomaly_training_model_threshold"),
-					resource.TestCheckResourceAttrSet("data.prismacloud_enterprise_settings.test", "anomaly_alert_disposition"),
 					resource.TestCheckResourceAttrSet("data.prismacloud_enterprise_settings.test", "user_attribution_in_notification"),
 					resource.TestCheckResourceAttrSet("data.prismacloud_enterprise_settings.test", "require_alert_dismissal_note"),
 					resource.TestCheckResourceAttrSet("data.prismacloud_enterprise_settings.test", "apply_default_policies_enabled"),
+					resource.TestCheckResourceAttrSet("data.prismacloud_enterprise_settings.test", "alarm_enabled"),
 				),
 			},
 		},

--- a/prismacloud/resource_enterprise_settings.go
+++ b/prismacloud/resource_enterprise_settings.go
@@ -7,7 +7,6 @@ import (
 	"github.com/paloaltonetworks/prisma-cloud-go/settings/enterprise"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 )
 
 func resourceEnterpriseSettings() *schema.Resource {
@@ -22,28 +21,15 @@ func resourceEnterpriseSettings() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"access_key_max_validity": {
+				Type:        schema.TypeInt,
+				Required:    true,
+				Description: "Access Keys maximum validity in days",
+			},
 			"session_timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Description: "Browser session timeout",
-			},
-			"anomaly_training_model_threshold": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Anomaly training model threshold",
-				ValidateFunc: validation.StringInSlice(
-					[]string{enterprise.Low, enterprise.Medium, enterprise.High},
-					false,
-				),
-			},
-			"anomaly_alert_disposition": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				Description: "Anomaly alert disposition",
-				ValidateFunc: validation.StringInSlice(
-					[]string{enterprise.Low, enterprise.Medium, enterprise.High},
-					false,
-				),
 			},
 			"user_attribution_in_notification": {
 				Type:        schema.TypeBool,
@@ -68,6 +54,12 @@ func resourceEnterpriseSettings() *schema.Resource {
 				Optional:    true,
 				Description: "Apply default policies enabled",
 			},
+			"alarm_enabled": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Alarms enabled",
+				Default:     true,
+			},
 		},
 	}
 }
@@ -80,28 +72,28 @@ func parseEnterpriseSettings(d *schema.ResourceData) enterprise.Config {
 	}
 
 	return enterprise.Config{
+		AccessKeyMaxValidity:          d.Get("access_key_max_validity").(int),
 		SessionTimeout:                d.Get("session_timeout").(int),
-		AnomalyTrainingModelThreshold: d.Get("anomaly_training_model_threshold").(string),
-		AnomalyAlertDisposition:       d.Get("anomaly_alert_disposition").(string),
 		UserAttributionInNotification: d.Get("user_attribution_in_notification").(bool),
 		RequireAlertDismissalNote:     d.Get("require_alert_dismissal_note").(bool),
 		DefaultPoliciesEnabled:        dpe,
 		ApplyDefaultPoliciesEnabled:   d.Get("apply_default_policies_enabled").(bool),
+		AlarmEnabled:                  d.Get("alarm_enabled").(bool),
 	}
 }
 
 func saveEnterpriseSettings(d *schema.ResourceData, conf enterprise.Config) {
 	var err error
 
+	d.Set("access_key_max_validity", conf.AccessKeyMaxValidity)
 	d.Set("session_timeout", conf.SessionTimeout)
-	d.Set("anomaly_training_model_threshold", conf.AnomalyTrainingModelThreshold)
-	d.Set("anomaly_alert_disposition", conf.AnomalyAlertDisposition)
 	d.Set("user_attribution_in_notification", conf.UserAttributionInNotification)
 	d.Set("require_alert_dismissal_note", conf.RequireAlertDismissalNote)
 	if err = d.Set("default_policies_enabled", conf.DefaultPoliciesEnabled); err != nil {
 		log.Printf("[WARN] Error setting 'default_policies_enabled' for %s: %s", d.Id(), err)
 	}
 	d.Set("apply_default_policies_enabled", conf.ApplyDefaultPoliciesEnabled)
+	d.Set("alarm_enabled", conf.AlarmEnabled)
 }
 
 func createUpdateEnterpriseSettings(d *schema.ResourceData, meta interface{}) error {

--- a/prismacloud/resource_enterprise_settings_test.go
+++ b/prismacloud/resource_enterprise_settings_test.go
@@ -84,12 +84,8 @@ func testAccCheckEnterpriseSettingsAttributes(o *enterprise.Config, tout int) re
 			return fmt.Errorf("Session timeout is %d, expected %d", o.SessionTimeout, tout)
 		}
 
-		if o.AnomalyTrainingModelThreshold != originalEnterpriseSettings.AnomalyTrainingModelThreshold {
-			return fmt.Errorf("Anomaly training model threshold is %q, expected %q", o.AnomalyTrainingModelThreshold, originalEnterpriseSettings.AnomalyTrainingModelThreshold)
-		}
-
-		if o.AnomalyAlertDisposition != originalEnterpriseSettings.AnomalyAlertDisposition {
-			return fmt.Errorf("Anomaly alert disposition is %q, expected %q", o.AnomalyAlertDisposition, originalEnterpriseSettings.AnomalyAlertDisposition)
+		if o.AccessKeyMaxValidity != originalEnterpriseSettings.AccessKeyMaxValidity {
+			return fmt.Errorf("Access keys max validity is %q, expected %q", o.AccessKeyMaxValidity, originalEnterpriseSettings.AccessKeyMaxValidity)
 		}
 
 		if o.UserAttributionInNotification != originalEnterpriseSettings.UserAttributionInNotification {
@@ -102,6 +98,10 @@ func testAccCheckEnterpriseSettingsAttributes(o *enterprise.Config, tout int) re
 
 		if o.ApplyDefaultPoliciesEnabled != originalEnterpriseSettings.ApplyDefaultPoliciesEnabled {
 			return fmt.Errorf("Apply default policies enabled is %t, expected %t", o.ApplyDefaultPoliciesEnabled, originalEnterpriseSettings.ApplyDefaultPoliciesEnabled)
+		}
+
+		if o.AlarmEnabled != originalEnterpriseSettings.AlarmEnabled {
+			return fmt.Errorf("Alarm enabled is %t, expected %t", o.AlarmEnabled, originalEnterpriseSettings.AlarmEnabled)
 		}
 
 		if len(o.DefaultPoliciesEnabled) != len(originalEnterpriseSettings.DefaultPoliciesEnabled) {
@@ -128,18 +128,18 @@ func testAccEnterpriseSettingsConfig(tout int) string {
 	buf.WriteString(fmt.Sprintf(`
 resource "prismacloud_enterprise_settings" "test" {
     session_timeout = %d
-    anomaly_training_model_threshold = %q
-    anomaly_alert_disposition = %q
+    access_key_max_validity = %d
     user_attribution_in_notification = %t
     require_alert_dismissal_note = %t
     apply_default_policies_enabled = %t
+    alarm_enabled = %t
     default_policies_enabled = {`,
 		tout,
-		originalEnterpriseSettings.AnomalyTrainingModelThreshold,
-		originalEnterpriseSettings.AnomalyAlertDisposition,
+		originalEnterpriseSettings.AccessKeyMaxValidity,
 		originalEnterpriseSettings.UserAttributionInNotification,
 		originalEnterpriseSettings.RequireAlertDismissalNote,
 		originalEnterpriseSettings.ApplyDefaultPoliciesEnabled,
+		originalEnterpriseSettings.AlarmEnabled,
 	))
 
 	for key, val := range originalEnterpriseSettings.DefaultPoliciesEnabled {


### PR DESCRIPTION
- Added support for `access_key_max_validity` and `alarm_enabled` parameters in resource `prismacloud_enterprise_settings`
- Removed parameters `anomaly_training_model_threshold` and `anomaly_alert_disposition` from the schema as these are not configurable from Prisma cloud Enterprise Settings API.