### PR TITLE
Enable imports for saved searches

### DIFF
--- a/docs/resources/saved_search.md
+++ b/docs/resources/saved_search.md
@@ -71,3 +71,11 @@ Only one of these can be defined:
 The following attributes are supported:
 
 * `saved` - (bool) This is set to `true` when the saved search is created.
+
+## Import
+
+Resources can be imported using the saved-search ID:
+
+```
+$ terraform import prismacloud_saved_search.example 11111111-2222-3333-4444-555555555555
+```

--- a/prismacloud/resource_saved_search.go
+++ b/prismacloud/resource_saved_search.go
@@ -12,6 +12,9 @@ func resourceSavedSearch() *schema.Resource {
 		Create: createSavedSearch,
 		Read:   readSavedSearch,
 		Delete: deleteSavedSearch,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			// Input.


### PR DESCRIPTION
## Description

The Saved Search resource does not currently support resource importing. This adds `Importer` to the Resource schema for saved-search resource.

## Motivation and Context

This PR will allow existing saved-search resources to be imported to the terraform state.

## How Has This Been Tested?

This change is fairly isolated and should only impact the saved-search resource. I tested this by compiling the provider on my machine and placing the compiled binary in my terraform plugins directory. I was successfully able to import an existing saved-search after the addition and there appeared to be no adverse side effects. This was tested on Terraform 0.12.31.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
