### PR TITLE
Adding changes to prevent AWS confused deputy attack

### DIFF
--- a/prismacloud/resource_cloud_account.go
+++ b/prismacloud/resource_cloud_account.go
@@ -65,9 +65,12 @@ func resourceCloudAccount() *schema.Resource {
 						},
 						"external_id": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 							Description: "AWS account external ID",
 							Sensitive:   true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return true
+							},
 						},
 						"group_ids": {
 							Type:        schema.TypeSet,

--- a/prismacloud/resource_org_cloud_account.go
+++ b/prismacloud/resource_org_cloud_account.go
@@ -63,9 +63,12 @@ func resourceOrgCloudAccount() *schema.Resource {
 						},
 						"external_id": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 							Description: "AWS account external ID",
 							Sensitive:   true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return true
+							},
 						},
 						"group_ids": {
 							Type:        schema.TypeSet,
@@ -105,8 +108,11 @@ func resourceOrgCloudAccount() *schema.Resource {
 						},
 						"member_external_id": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
 							Description: "AWS Member account role's external ID",
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return true
+							},
 						},
 						"member_role_status": {
 							Type:        schema.TypeBool,


### PR DESCRIPTION
- Changing external_id from required to optional
- Adding DiffSupress function to avoid the drift for external_id