### PR TITLE
Adding sample code for custom build & run policies to the Docs

### DIFF
--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -59,7 +59,7 @@ resource "prismacloud_policy" "example" {
   name        = "sample custom run policy created with terraform"
   severity = "low"
   labels      = ["some_tag"]
-  description = "sample custom run policy created with terraform"
+  description = "this describes the policy"
   rule {
     name     = "sample custom run policy created with terraform"
     rule_type = "Config"
@@ -75,19 +75,44 @@ resource "prismacloud_policy" "example" {
 ## Example Usage (Custom Run Policy with an RQL saved search)
 ```hcl
 resource "prismacloud_policy" "example" {
-  policy_type = "config"
-  cloud_type  = "aws"
   name        = "sample custom run policy created with terraform"
-  severity = "low"
+  policy_type = "config"
+  cloud_type  = "azure"
+  severity    = "low"
   labels      = ["some_tag"]
-  description = "sample custom run policy created with terraform"
+  description = "this describes the policy"
+  enabled     = false
   rule {
-    name     = "sample custom run policy created with terraform"
+    name      = "sample custom run policy created with terraform"
     rule_type = "Config"
-    criteria = file("folder/run_policy.rql")
     parameters = {
-      savedSearch = false
+      savedSearch = true
       withIac     = false
+    }
+    criteria = file("policies/aks/aks001.rql")
+  }
+}
+
+resource "prismacloud_saved_search" "example" {
+  name        = "example"
+  description = "sample saved RQL search"
+  search_id   = prismacloud_rql_search.example.search_id
+  query       = prismacloud_rql_search.example.query
+  time_range {
+    relative {
+      unit   = prismacloud_rql_search.example.time_range.0.relative.0.unit
+      amount = prismacloud_rql_search.example.time_range.0.relative.0.amount
+    }
+  }
+}
+
+resource "prismacloud_rql_search" "example" {
+  search_type = "config"
+  query       = "config from cloud.resource where api.name = 'azure-kubernetes-cluster' AND json.rule = properties.enableRBAC is true'"
+  time_range {
+    relative {
+      unit   = "hour"
+      amount = 24
     }
   }
 }

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -38,7 +38,7 @@ resource "prismacloud_policy" "example" {
     rule_type = "Config"
     parameters = {
       savedSearch = false
-      withIac     = false
+      withIac     = true
     }
     children {
       type           = "build"
@@ -87,7 +87,7 @@ resource "prismacloud_policy" "example" {
     rule_type = "Config"
     parameters = {
       savedSearch = true
-      withIac     = false
+      withIac     = true
     }
     criteria = file("policies/aks/aks001.rql")
   }

--- a/docs/resources/policy.md
+++ b/docs/resources/policy.md
@@ -16,11 +16,80 @@ resource "prismacloud_policy" "example" {
         name = "my rule"
         criteria = "savedSearchId"
         parameters = {
-            "savedSearch": "true",
-            "withIac": "false",
+          savedSearch = false
+          withIac     = false
         }
         rule_type = "Network"
     }
+}
+```
+
+## Example Usage (Custom Build Policy)
+```hcl
+resource "prismacloud_policy" "example" {
+  name        = "sample custom build policy created with terraform"
+  policy_type = "config"
+  cloud_type  = "aws"
+  severity    = "high"
+  labels      = ["some_tag"]
+  description = "this describes the policy"
+  rule {
+    name = "sample custom build policy created with terraform"
+    rule_type = "Config"
+    parameters = {
+      savedSearch = false
+      withIac     = false
+    }
+    children {
+      type           = "build"
+      recommendation = "fix it"
+      metadata = {
+        "code" : file("folder/build_policy.yaml"),
+      }
+    }
+  }
+} 
+```
+
+## Example Usage (Custom Run Policy without any RQL saved search)
+```hcl
+resource "prismacloud_policy" "example" {
+  policy_type = "config"
+  cloud_type  = "aws"
+  name        = "sample custom run policy created with terraform"
+  severity = "low"
+  labels      = ["some_tag"]
+  description = "sample custom run policy created with terraform"
+  rule {
+    name     = "sample custom run policy created with terraform"
+    rule_type = "Config"
+    parameters = {
+      savedSearch = false
+      withIac     = false
+    }
+    criteria = file("folder/run_policy.rql")
+  }
+}
+```
+
+## Example Usage (Custom Run Policy with an RQL saved search)
+```hcl
+resource "prismacloud_policy" "example" {
+  policy_type = "config"
+  cloud_type  = "aws"
+  name        = "sample custom run policy created with terraform"
+  severity = "low"
+  labels      = ["some_tag"]
+  description = "sample custom run policy created with terraform"
+  rule {
+    name     = "sample custom run policy created with terraform"
+    rule_type = "Config"
+    criteria = file("folder/run_policy.rql")
+    parameters = {
+      savedSearch = false
+      withIac     = false
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Description

Adding documentation for the policy resource to include some sample code for custom build policy and run policy.

## Motivation and Context

Without some sample code, it is actually difficult to find out the exact syntax for custom policies.

## How Has This Been Tested?

Sample code has been fully tested in PSOLlab environment. 
Resources  were successfully created and deployed to our PSO Lab Prisma Cloud tenant (app2). 
The policy rules can then be inspected in the UI. 
Policies were updated and verified in the UI.
Resources were successfully destroyed.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
