### PR TITLE
Add support for GCP workspace domain cloud account

### DIFF
--- a/docs/data-sources/cloud_account_supported_features.md
+++ b/docs/data-sources/cloud_account_supported_features.md
@@ -28,7 +28,7 @@ output "features_supported" {
 The following are the params that this data source supports:
 
 * `cloud_type` - (Required) Cloud type. `aws`, `azure`, or `gcp`.
-* `account_type` - (Required) Cloud account type. `account`, `organization`, `masterServiceAccount`, or `tenant`. Supported values based on cloud_type are given below. <br /> - account, organization - cloud_type: **aws**<br /> - account, organization, masterServiceAccount - cloud_type: **gcp** <br /> - account, tenant - cloud_type: **azure**
+* `account_type` - (Required) Cloud account type. `account`, `organization`, `masterServiceAccount`, `tenant` or `workspace_domain`. Supported values based on cloud_type are given below. <br /> - account, organization - cloud_type: **aws**<br /> - account, organization, masterServiceAccount, workspace_domain - cloud_type: **gcp** <br /> - account, tenant - cloud_type: **azure**
 * `deployment_type` - (Optional) *Applicable only for cloud_type: **azure***. Possible values: `azure`, `azure_gov`, or `azure_china`. <br /> - **azure** -  Account type is commercial<br /> - **azure_gov** - Account type is Government on Prisma Commercial and Government stacks.<br /> - **azure_china** - Prisma China Stack.
 * `aws_partition` - (Optional) *Applicable only for Prisma Government Stack(**app.gov.prismacloud.io**) and given if the Cloud account Global Deployment option is enabled.<br />* - **us-east-1** -  AWS Commercial/Global account.<br /> - **us-gov-west-1** - AWS GovCloud account.
 * `root_sync_enabled` - (Optional) *Applicable only for cloud_type: **azure** and accountType: **tenant***.<br />  In order to get supported features for accountType **tenant** and its associated **management groups** and **subscriptions**, rootSyncEnabled must be set to true.

--- a/docs/resources/cloud_account_v2.md
+++ b/docs/resources/cloud_account_v2.md
@@ -7,20 +7,24 @@ page_title: "Prisma Cloud: prismacloud_cloud_account_v2"
 Manage a cloud account on the Prisma Cloud platform.
 
 ## **Example Usage 1**: AWS cloud account onboarding
-### `Step 1`: Fetch the supported features. Refer **[Supported features readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/cloud_account_supported_features)** for more details.
+
+### `Step 1`: Fetch the supported features. Refer **[Supported features readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/cloud_account_supported_features)** for more details
+
 ```hcl
 data "prismacloud_account_supported_features" "prismacloud_supported_features" {
     cloud_type = "aws"
     account_type = "account"
 }
 ```
+
 ```hcl
 output "features_supported" {
     value = data.prismacloud_account_supported_features.prismacloud_supported_features.supported_features
 }
 ```
 
-### `Step 2`: Fetch the AWS CFT s3 presigned url based on required features. Refer **[AWS CFT generator Readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/aws_cft_generator_external_id)** for more details.
+### `Step 2`: Fetch the AWS CFT s3 presigned url based on required features. Refer **[AWS CFT generator Readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/aws_cft_generator_external_id)** for more details
+
 ```hcl
 data "prismacloud_aws_cft_generator" "prismacloud_account_cft" {
     account_type = "account"
@@ -28,6 +32,7 @@ data "prismacloud_aws_cft_generator" "prismacloud_account_cft" {
     features = data.prismacloud_account_supported_features.prismacloud_supported_features.supported_features
 }
 ```
+
 ```hcl
 output "s3_presigned_cft_url" {
     value = data.prismacloud_aws_cft_generator.prismacloud_account_cft.s3_presigned_cft_url
@@ -35,10 +40,12 @@ output "s3_presigned_cft_url" {
 ```
 
 ### `Step 3`: Create the IAM Role AWS CloudFormation Stack using S3 presigned cft url from above step2
-To create the IAM role using terraform, the aws official terraform aws_cloudformation_stack resource can be used. Refer https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack for more details
+
+To create the IAM role using terraform, the aws official terraform aws_cloudformation_stack resource can be used. Refer <https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudformation_stack> for more details
 
 Example:
-```
+
+```hcl
 resource "aws_cloudformation_stack" "prismacloud_iam_role_stack" {
   name = "PrismaCloudApp" // change if needed
   capabilities = ["CAPABILITY_NAMED_IAM"]
@@ -95,9 +102,10 @@ data "prismacloud_account_group" "existing_account_group_id" {
 # }
 
 ```
+
 ### **Consolidated code snippet for all the above steps**
 
-```
+```hcl
 data "prismacloud_account_supported_features" "prismacloud_supported_features" {
     cloud_type = "aws"
     account_type = "account"
@@ -158,7 +166,8 @@ data "prismacloud_account_group" "existing_account_group_id" {
 ```
 
 ## **Example Usage 2**: Bulk AWS cloud accounts onboarding
-### `Prerequisite Step`: Steps 1, 2, 3 mentioned in 'Example Usage 1' should be completed for each of the account and have IAM roles created.
+
+### `Prerequisite Step`: Steps 1, 2, 3 mentioned in 'Example Usage 1' should be completed for each of the account and have IAM roles created
 
 /*
 You can also create cloud accounts from a CSV file using native Terraform
@@ -171,7 +180,8 @@ accountId,groupIDs,name,roleArn
 321466019,Default Account Group ID||AWS Account Group ID,321466019,arn:aws:iam::321466019:role/RedlockReadWriteRole
 
 */
-```
+
+```hcl
 locals {
     instances = csvdecode(file("aws.csv"))
 }
@@ -195,7 +205,7 @@ Before onboarding the aws cloud account. `external_id` for account must be gener
 
 ## **Example Usage 3**: Azure cloud account onboarding
 
-### `Step 1`: Fetch the supported features. Refer **[Supported features readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/cloud_account_supported_features)** for more details.
+### `Step 1`: Fetch the supported features. Refer **[Supported features readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/cloud_account_supported_features)** for more details
 
 ```hcl
 data "prismacloud_account_supported_features" "prismacloud_supported_features" {
@@ -211,7 +221,7 @@ output "features_supported" {
 }
 ```
 
-### `Step 2`: Fetch the Azure template based on required features. Refer **[Azure template generator Readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/azure_template)** for more details.
+### `Step 2`: Fetch the Azure template based on required features. Refer **[Azure template generator Readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/azure_template)** for more details
 
 ```hcl
 data "prismacloud_azure_template" "prismacloud_azure_template" {
@@ -272,7 +282,7 @@ data "prismacloud_account_group" "existing_account_group_id" {
 
 ### **Consolidated code snippet for all the above steps**
 
-```
+```hcl
 data "prismacloud_account_supported_features" "prismacloud_supported_features" {
   cloud_type      = "azure"
   account_type    = "account"
@@ -330,7 +340,7 @@ data "prismacloud_account_group" "existing_account_group_id" {
 
 ## **Example Usage 4**: Bulk Azure cloud accounts onboarding
 
-### `Prerequisite Step`: Steps 1, 2, 3 mentioned in 'Example Usage 3' should be completed for each of the account.
+### `Prerequisite Step`: Steps 1, 2, 3 mentioned in 'Example Usage 3' should be completed for each of the account
 
 /*
 You can also create cloud accounts from a CSV file using native Terraform
@@ -344,7 +354,7 @@ accountId,groupIDs,name,clientId,key,tenantId,servicePrincipalId
 
 */
 
-```
+```hcl
 locals {
     instances = csvdecode(file("azure.csv"))
 }
@@ -371,7 +381,7 @@ Before onboarding the azure cloud account. `azure_template` for account must be 
 
 ## **Example Usage 5**: Gcp cloud account onboarding
 
-### `Step 1`: Fetch the supported features. Refer **[Supported features readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/cloud_account_supported_features)** for more details.
+### `Step 1`: Fetch the supported features. Refer **[Supported features readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/cloud_account_supported_features)** for more details
 
 ```hcl
 data "prismacloud_account_supported_features" "prismacloud_supported_features" {
@@ -386,7 +396,7 @@ output "features_supported" {
 }
 ```
 
-### `Step 2`: Fetch the Gcp template based on required features. Refer **[Gcp template generator Readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/gcp_template)** for more details.
+### `Step 2`: Fetch the Gcp template based on required features. Refer **[Gcp template generator Readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/gcp_template)** for more details
 
 ```hcl
 data "prismacloud_gcp_template" "prismacloud_gcp_template" {
@@ -446,7 +456,7 @@ data "prismacloud_account_group" "existing_account_group_id" {
 
 ### **Consolidated code snippet for all the above steps**
 
-```
+```hcl
 data "prismacloud_account_supported_features" "prismacloud_supported_features" {
   cloud_type      = "gcp"
   account_type    = "<account-type>"   //"account" or "masterServiceAccount"
@@ -502,7 +512,7 @@ data "prismacloud_account_group" "existing_account_group_id" {
 
 ## **Example Usage 6**: Bulk Gcp cloud accounts onboarding
 
-### `Prerequisite Step`: Steps 1, 2, 3 mentioned in 'Example Usage 5' should be completed for each of the account.
+### `Prerequisite Step`: Steps 1, 2, 3 mentioned in 'Example Usage 5' should be completed for each of the account
 
 /*
 You can also create cloud accounts from a CSV file using native Terraform
@@ -516,7 +526,7 @@ accountId,groupIDs,name,credentials
 
 */
 
-```
+```hcl
 locals {
     instances = csvdecode(file("gcp.csv"))
 }
@@ -540,7 +550,7 @@ Before onboarding the gcp cloud account. `gcp_template` for account must be gene
 
 ## **Example Usage 7**: IBM cloud account onboarding
 
-### `Step 1`: Fetch the IBM template. Refer **[IBM template generator Readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/ibm_template)** for more details.
+### `Step 1`: Fetch the IBM template. Refer **[IBM template generator Readme](https://registry.terraform.io/providers/PaloAltoNetworks/prismacloud/latest/docs/data-sources/ibm_template)** for more details
 
 ```hcl
 data "prismacloud_ibm_template" "prismacloud_ibm_template" {
@@ -586,7 +596,7 @@ data "prismacloud_account_group" "existing_account_group_id" {
 
 ### **Consolidated code snippet for all the above steps**
 
-```
+```hcl
 data "prismacloud_ibm_template" "prismacloud_ibm_template" {
   file_name       = "<file-name>" //Provide filename along with path to store gcp template
   account_type    = "account"
@@ -623,7 +633,7 @@ data "prismacloud_account_group" "existing_account_group_id" {
 
 ## **Example Usage 8**: Bulk IBM cloud accounts onboarding
 
-### `Prerequisite Step`: Steps 1, 2 mentioned in 'Example Usage 7' should be completed for each of the account.
+### `Prerequisite Step`: Steps 1, 2 mentioned in 'Example Usage 7' should be completed for each of the account
 
 /*
 You can also create cloud accounts from a CSV file using native Terraform
@@ -637,7 +647,7 @@ accountId,apiKey,groupIds,name,svcIdIamId
 
 */
 
-```
+```hcl
 locals {
     instances = csvdecode(file("ibm.csv"))
 }
@@ -708,7 +718,7 @@ accountId,ramArn,groupIds,name
 
 */
 
-```
+```hcl
 locals {
     instances = csvdecode(file("alibaba.csv"))
 }
@@ -847,7 +857,7 @@ The type of cloud account to add.
 ### Gcp
 
 * `account_id` - Gcp account ID.
-* `account_type` - `account` for gcp project account and `masterServiceAccount` for gcp master service account.
+* `account_type` - `account` for gcp project account, `masterServiceAccount` for gcp master service account and `workspace_domain` for gcp workspace domain.
 * `enabled` - (bool) Whether the account is enabled.
 * `group_ids` - List of account IDs to which you are assigning this account.
 * `name` - Name to be used for the account on the Prisma Cloud platform (must be unique).
@@ -934,5 +944,5 @@ The type of cloud account to add.
 Resources can be imported using the cloud type and the ID:
 
 ```
-$ terraform import prismacloud_cloud_account_v2.example cloudType:accountId
+terraform import prismacloud_cloud_account_v2.example cloudType:accountId
 ```

--- a/prismacloud/data_source_cloud_account_supported_features.go
+++ b/prismacloud/data_source_cloud_account_supported_features.go
@@ -24,6 +24,7 @@ func dataSourceCloudAccountSupportedFeatures() *schema.Resource {
 						"organization",
 						"masterServiceAccount",
 						"tenant",
+						"workspace_domain",
 					},
 					false,
 				),

--- a/prismacloud/data_source_policy.go
+++ b/prismacloud/data_source_policy.go
@@ -302,8 +302,8 @@ func dataSourcePolicy() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"operation": {
-								  		Type:     schema.TypeString,
-								  		Computed: true,
+										Type:     schema.TypeString,
+										Computed: true,
 									},
 									"payload": {
 										Type:     schema.TypeString,

--- a/prismacloud/resource_login_ip_status.go
+++ b/prismacloud/resource_login_ip_status.go
@@ -71,7 +71,7 @@ func updateLoginIpStatus(ctx context.Context, d *schema.ResourceData, meta inter
 	return readLoginIpStatus(ctx, d, meta)
 }
 
-//done
+// done
 func readLoginIpStatus(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*pc.Client)
 
@@ -85,7 +85,7 @@ func readLoginIpStatus(ctx context.Context, d *schema.ResourceData, meta interfa
 	return nil
 }
 
-//done
+// done
 func deleteLoginIpStatus(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	return nil
 }

--- a/prismacloud/resource_org_cloud_account_v2.go
+++ b/prismacloud/resource_org_cloud_account_v2.go
@@ -3,12 +3,13 @@ package prismacloud
 import (
 	"context"
 	"encoding/json"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	pc "github.com/paloaltonetworks/prisma-cloud-go"
-	accountv2 "github.com/paloaltonetworks/prisma-cloud-go/cloud/account-v2"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	pc "github.com/paloaltonetworks/prisma-cloud-go"
+	accountv2 "github.com/paloaltonetworks/prisma-cloud-go/cloud/account-v2"
 
 	"github.com/paloaltonetworks/prisma-cloud-go/cloud/account-v2/org"
 

--- a/prismacloud/resource_policy.go
+++ b/prismacloud/resource_policy.go
@@ -386,8 +386,8 @@ func resourcePolicy() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"operation": {
-								  		Type:     schema.TypeString,
-								  		Optional: true,
+										Type:     schema.TypeString,
+										Optional: true,
 									},
 									"payload": {
 										Type:     schema.TypeString,
@@ -534,8 +534,8 @@ func parsePolicy(d *schema.ResourceData, id string) policy.Policy {
 				actions := make([]policy.Action, 0, len(rems["actions"].([]interface{})))
 				for _, action := range rems["actions"].([]interface{}) {
 					actions = append(actions, policy.Action{
-						Operation:    action.(map[string]interface{})["operation"].(string),
-						Payload: action.(map[string]interface{})["payload"].(string),
+						Operation: action.(map[string]interface{})["operation"].(string),
+						Payload:   action.(map[string]interface{})["payload"].(string),
 					})
 				}
 				ans.Remediation.Actions = actions
@@ -680,7 +680,7 @@ func savePolicy(d *schema.ResourceData, obj policy.Policy) {
 			csjs = string(b)
 		}
 		var actions []map[string]string
-		if obj.Remediation.Actions != nil  && len(obj.Remediation.Actions) > 0 {
+		if obj.Remediation.Actions != nil && len(obj.Remediation.Actions) > 0 {
 			actions = make([]map[string]string, len(obj.Remediation.Actions))
 			for i, action := range obj.Remediation.Actions {
 				actions[i] = map[string]string{
@@ -696,7 +696,7 @@ func savePolicy(d *schema.ResourceData, obj policy.Policy) {
 			"actions":                       actions,
 			"cli_script_json_schema_string": csjs,
 		}
-		if err := d.Set("remediation", []interface{}{rem} ); err != nil {
+		if err := d.Set("remediation", []interface{}{rem}); err != nil {
 			log.Printf("[WARN] Error setting 'remediation' for %q: %s", d.Id(), err)
 		}
 	}

--- a/prismacloud/resource_saved_search.go
+++ b/prismacloud/resource_saved_search.go
@@ -151,8 +151,6 @@ func readSavedSearch(ctx context.Context, d *schema.ResourceData, meta interface
 	return nil
 }
 
-
-
 func deleteSavedSearch(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*pc.Client)
 	id := d.Id()

--- a/prismacloud/resource_user_role.go
+++ b/prismacloud/resource_user_role.go
@@ -6,8 +6,8 @@ import (
 	"log"
 
 	pc "github.com/paloaltonetworks/prisma-cloud-go"
-	"github.com/paloaltonetworks/prisma-cloud-go/user/role"
 	"github.com/paloaltonetworks/prisma-cloud-go/user/profile"
+	"github.com/paloaltonetworks/prisma-cloud-go/user/role"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -37,7 +37,7 @@ func resourceUserRole() *schema.Resource {
 			"delete_associated_users": {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:	 false,
+				Default:     false,
 				Description: "Delete any associated users on role deletion. This is use useful when SSO is enabled",
 			},
 			"description": {

--- a/prismacloud/resource_v2_cloud_account.go
+++ b/prismacloud/resource_v2_cloud_account.go
@@ -2,13 +2,14 @@ package prismacloud
 
 import (
 	"encoding/json"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/paloaltonetworks/prisma-cloud-go/cloud/account-v2"
-	"golang.org/x/net/context"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	accountv2 "github.com/paloaltonetworks/prisma-cloud-go/cloud/account-v2"
+	"golang.org/x/net/context"
 
 	pc "github.com/paloaltonetworks/prisma-cloud-go"
 
@@ -443,12 +444,13 @@ func resourceV2CloudAccount() *schema.Resource {
 						"account_type": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Account type - account, masterServiceAccount or organization",
+							Description: "Account type - account, masterServiceAccount, organization or workspace_domain",
 							ValidateFunc: validation.StringInSlice(
 								[]string{
 									"account",
 									"masterServiceAccount",
 									"organization",
+									"workspace_domain",
 								},
 								false,
 							),


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

The Prisma API is already supporting the GCP Workspace domain as cloud account type. This should be also possible to use via the Prisma Cloud terraform provider.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Prismacloud &  supports the onboarding of a Google Workspace Domain. However it's not supported by the provider.
https://pan.dev/prisma-cloud/api/cspm/add-gcp-cloud-account/

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`make test` is running without any issues.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
