### PR TITLE
feat: Add SAML bypass users management resources

### DIFF
--- a/docs/data-sources/saml_bypass_users.md
+++ b/docs/data-sources/saml_bypass_users.md
@@ -1,0 +1,25 @@
+# prismacloud_saml_bypass_users Data Source
+
+The `prismacloud_saml_bypass_users` data source retrieves the list of users that are allowed to bypass SAML authentication.
+
+## Example Usage
+
+```hcl
+provider "prismacloud" {
+  # Provider configuration
+}
+
+data "prismacloud_saml_bypass_users" "example" {}
+
+output "bypass_users" {
+  value = data.prismacloud_saml_bypass_users.example.usernames
+}
+```
+
+## Argument Reference
+
+No arguments are required for this data source.
+
+## Attributes Reference
+
+- `usernames` - (Computed) List of usernames that are allowed to bypass SAML authentication.

--- a/docs/resources/saml_bypass_subset_users.md
+++ b/docs/resources/saml_bypass_subset_users.md
@@ -1,0 +1,33 @@
+# prismacloud_saml_bypass_subset_users Resource
+
+The `prismacloud_saml_bypass_subset_users` resource allows you to manage a subset of users that are allowed to bypass SAML authentication. Unlike `prismacloud_saml_bypass_users` which manages the complete list, this resource only adds or removes the specified users while preserving other users that may be managed outside of Terraform.
+
+## Example Usage
+
+```hcl
+provider "prismacloud" {
+  # Provider configuration
+}
+
+resource "prismacloud_saml_bypass_subset_users" "example" {
+  usernames = ["admin", "backup-user"]
+}
+```
+
+## Argument Reference
+
+- `usernames` - (Required) List of usernames that are allowed to bypass SAML authentication. This resource will add these users to the existing list and remove them when they are no longer in the configuration, but will preserve other users not managed by this resource.
+
+## Import
+
+The resource can be imported using a simple identifier:
+
+```shell
+hcl terraform import prismacloud_saml_bypass_subset_users.example saml_bypass_subset_users
+```
+
+## Notes
+
+- This resource is designed for scenarios where you want to manage only a subset of SAML bypass users while allowing other users to be managed through other means (e.g., manually or by other Terraform configurations).
+- When users are removed from this resource's configuration, they will be removed from the SAML bypass list, but other users not managed by this resource will remain.
+- For managing the complete list of SAML bypass users, use the `prismacloud_saml_bypass_users` resource instead.

--- a/docs/resources/saml_bypass_users.md
+++ b/docs/resources/saml_bypass_users.md
@@ -1,0 +1,27 @@
+# prismacloud_saml_bypass_users Resource
+
+The `prismacloud_saml_bypass_users` resource allows you to manage the list of users that are allowed to bypass SAML authentication.
+
+## Example Usage
+
+```hcl
+provider "prismacloud" {
+  # Provider configuration
+}
+
+resource "prismacloud_saml_bypass_users" "example" {
+  usernames = ["admin", "backup-user", "support-user"]
+}
+```
+
+## Argument Reference
+
+- `usernames` - (Required) List of usernames that are allowed to bypass SAML authentication.
+
+## Import
+
+The resource can be imported using a simple identifier:
+
+```shell
+hcl terraform import prismacloud_saml_bypass_users.example saml_bypass_users
+```

--- a/prismacloud/data_source_saml_bypass_users.go
+++ b/prismacloud/data_source_saml_bypass_users.go
@@ -1,0 +1,45 @@
+package prismacloud
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	pc "github.com/paloaltonetworks/prisma-cloud-go"
+	"github.com/paloaltonetworks/prisma-cloud-go/user/saml"
+)
+
+func dataSourceSamlBypassUsers() *schema.Resource {
+	return &schema.Resource{
+		ReadContext: dataSourceSamlBypassUsersRead,
+		Schema: map[string]*schema.Schema{
+			"usernames": {
+				Type:        schema.TypeList,
+				Computed:    true,
+				Description: "List of usernames that are allowed to bypass SAML authentication.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+		Description: "Retrieve the list of users that are allowed to bypass SAML authentication.",
+	}
+}
+
+func dataSourceSamlBypassUsersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+	log.Printf("[DEBUG] Starting dataSourceSamlBypassUsersRead")
+	usernames, err := saml.GetBypassUsers(c)
+	log.Printf("[DEBUG] dataSourceSamlBypassUsersRead - Got usernames: %v", usernames)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("usernames", usernames); err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("saml_bypass_users")
+	return nil
+}

--- a/prismacloud/data_source_saml_bypass_users_test.go
+++ b/prismacloud/data_source_saml_bypass_users_test.go
@@ -1,0 +1,32 @@
+package prismacloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceSamlBypassUsers(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceSamlBypassUsersConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.prismacloud_saml_bypass_users.test", "usernames"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceSamlBypassUsersConfig() string {
+	return `
+provider "prismacloud" {
+  # Provider configuration would go here
+}
+
+data "prismacloud_saml_bypass_users" "test" {}
+`
+}

--- a/prismacloud/provider.go
+++ b/prismacloud/provider.go
@@ -167,6 +167,7 @@ func Provider() *schema.Provider {
 			"prismacloud_trusted_login_ip":                         dataSourceTrustedLoginIp(),
 			"prismacloud_trusted_login_ips":                        dataSourceTrustedLoginIps(),
 			"prismacloud_aws_storage_uuid":                         dataSourceStorageUUID(),
+			"prismacloud_saml_bypass_users":                        dataSourceSamlBypassUsers(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -198,6 +199,8 @@ func Provider() *schema.Provider {
 			"prismacloud_trusted_alert_ip":                        resourceTrustedAlertIp(),
 			"prismacloud_trusted_login_ip":                        resourceTrustedLoginIp(),
 			"prismacloud_trusted_login_ip_status":                 resourceLoginIpStatus(),
+			"prismacloud_saml_bypass_users":                       resourceSamlBypassUsers(),
+			"prismacloud_saml_bypass_subset_users":                resourceSamlBypassSubsetUsers(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/prismacloud/resource_saml_bypass_subset_users.go
+++ b/prismacloud/resource_saml_bypass_subset_users.go
@@ -1,0 +1,179 @@
+package prismacloud
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	pc "github.com/paloaltonetworks/prisma-cloud-go"
+	"github.com/paloaltonetworks/prisma-cloud-go/user/saml"
+)
+
+func resourceSamlBypassSubsetUsers() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSamlBypassSubsetUsersCreate,
+		ReadContext:   resourceSamlBypassSubsetUsersRead,
+		UpdateContext: resourceSamlBypassSubsetUsersUpdate,
+		DeleteContext: resourceSamlBypassSubsetUsersDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"usernames": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "List of usernames that are allowed to bypass SAML authentication.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+		Description: "Manage a subset of users that are allowed to bypass SAML authentication. This resource adds or removes only the specified users while preserving other users that may be managed outside of Terraform.",
+	}
+}
+
+func resourceSamlBypassSubsetUsersCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+	log.Printf("[DEBUG] Starting resourceSamlBypassSubsetUsersCreate")
+	usernames := convertStringSet(d.Get("usernames"))
+
+	// Get the current list of users from the API
+	currentUsers, err := saml.GetBypassUsers(c)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Reconcile the current users with the new users
+	updatedUsers := reconcileUsers(currentUsers, usernames, []string{})
+
+	// Update the API with the updated list
+	log.Printf("[DEBUG] resourceSamlBypassSubsetUsersCreate Updated users list to send to API: %v", updatedUsers)
+	err = saml.UpdateBypassUsers(c, updatedUsers)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("saml_bypass_subset_users")
+	return resourceSamlBypassSubsetUsersRead(ctx, d, meta)
+}
+
+func resourceSamlBypassSubsetUsersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+	log.Printf("[DEBUG] Starting resourceSamlBypassSubsetUsersRead")
+	// Get the current list of users from the API
+	currentUsers, err := saml.GetBypassUsers(c)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Get the list of users managed by Terraform
+	terraformUsers := convertStringSet(d.Get("usernames"))
+
+	// Save the list of users managed by Terraform
+	saveSamlBypassSubsetUsers(d, terraformUsers)
+
+	// Output for debugging
+	log.Printf("[DEBUG] resourceSamlBypassSubsetUsersRead Current users from API: %v", currentUsers)
+	log.Printf("[DEBUG] resourceSamlBypassSubsetUsersRead Terraform-managed users: %v", terraformUsers)
+
+	return nil
+}
+
+func resourceSamlBypassSubsetUsersUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+	log.Printf("[DEBUG] Starting resourceSamlBypassSubsetUsersUpdate")
+	// Get the current list of users from the API
+	currentUsers, err := saml.GetBypassUsers(c)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Get the previous and current list of users managed by Terraform
+	oldUsers, newUsers := d.GetChange("usernames")
+	oldUsersList := convertStringSet(oldUsers)
+	newUsersList := convertStringSet(newUsers)
+
+	// Reconcile the users
+	updatedUsers := reconcileUsers(currentUsers, newUsersList, oldUsersList)
+
+	// Update the API with the updated list
+	log.Printf("[DEBUG] resourceSamlBypassSubsetUsersUpdate - Updated users to send to API: %v", updatedUsers)
+	err = saml.UpdateBypassUsers(c, updatedUsers)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceSamlBypassSubsetUsersRead(ctx, d, meta)
+}
+
+func resourceSamlBypassSubsetUsersDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+
+	log.Printf("[DEBUG] Starting resourceSamlBypassSubsetUsersDelete")
+	// Get the current list of users from the API
+	currentUsers, err := saml.GetBypassUsers(c)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	// Get the list of users managed by Terraform
+	terraformUsers := convertStringSet(d.Get("usernames"))
+
+	// Remove the Terraform-managed users from the current list
+	updatedUsers := reconcileUsers(currentUsers, []string{}, terraformUsers)
+	// Update the API with the updated list
+	log.Printf("[DEBUG] resourceSamlBypassSubsetUsersDelete Updated users to send to API: %v", updatedUsers)
+	err = saml.UpdateBypassUsers(c, updatedUsers)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// reconcileUsers reconciles the current users with the new users managed by Terraform
+func reconcileUsers(currentUsers []string, newUsers []string, oldUsers []string) []string {
+	// Add new users that are not already in the current list
+	for _, user := range newUsers {
+		if !contains(currentUsers, user) {
+			currentUsers = append(currentUsers, user)
+		}
+	}
+
+	// Remove users that are no longer in the new list but were in the old list
+	for _, user := range oldUsers {
+		if !contains(newUsers, user) && contains(currentUsers, user) {
+			currentUsers = remove(currentUsers, user)
+		}
+	}
+	return currentUsers
+}
+
+func saveSamlBypassSubsetUsers(d *schema.ResourceData, usernames []string) error {
+	// Save the list of users managed by Terraform
+	if err := d.Set("usernames", usernames); err != nil {
+		return err
+	}
+	return nil
+}
+
+// contains checks if a string is present in a slice
+func contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}
+
+// remove removes a string from a slice
+func remove(slice []string, item string) []string {
+	for i, s := range slice {
+		if s == item {
+			return append(slice[:i], slice[i+1:]...)
+		}
+	}
+	return slice
+}

--- a/prismacloud/resource_saml_bypass_subset_users_test.go
+++ b/prismacloud/resource_saml_bypass_subset_users_test.go
@@ -1,0 +1,65 @@
+package prismacloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceSamlBypassSubsetUsers(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceSamlBypassSubsetUsersConfig("user1", "user2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_subset_users.test", "usernames.#", "2"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_subset_users.test", "usernames.0", "user1"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_subset_users.test", "usernames.1", "user2"),
+				),
+			},
+			{
+				Config: testAccResourceSamlBypassSubsetUsersConfig("user1", "user2", "user3"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_subset_users.test", "usernames.#", "3"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_subset_users.test", "usernames.0", "user1"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_subset_users.test", "usernames.1", "user2"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_subset_users.test", "usernames.2", "user3"),
+				),
+			},
+			{
+				Config: testAccResourceSamlBypassSubsetUsersConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_subset_users.test", "usernames.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceSamlBypassSubsetUsersConfig(usernames ...string) string {
+	config := `
+provider "prismacloud" {
+  # Provider configuration would go here
+}
+
+resource "prismacloud_saml_bypass_subset_users" "test" {
+  usernames = [
+`
+
+	for i, username := range usernames {
+		config += `	"` + username + `"`
+		if i < len(usernames)-1 {
+			config += `,
+`
+		}
+	}
+
+	config += `
+  ]
+}
+`
+
+	return config
+}

--- a/prismacloud/resource_saml_bypass_users.go
+++ b/prismacloud/resource_saml_bypass_users.go
@@ -1,0 +1,99 @@
+package prismacloud
+
+import (
+	"context"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	pc "github.com/paloaltonetworks/prisma-cloud-go"
+	"github.com/paloaltonetworks/prisma-cloud-go/user/saml"
+)
+
+func resourceSamlBypassUsers() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: resourceSamlBypassUsersCreate,
+		ReadContext:   resourceSamlBypassUsersRead,
+		UpdateContext: resourceSamlBypassUsersUpdate,
+		DeleteContext: resourceSamlBypassUsersDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+		Schema: map[string]*schema.Schema{
+			"usernames": {
+				Type:        schema.TypeSet,
+				Required:    true,
+				Description: "List of usernames that are allowed to bypass SAML authentication.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+		Description: "Manage the list of users that are allowed to bypass SAML authentication.",
+	}
+}
+
+func resourceSamlBypassUsersCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+	log.Printf("[DEBUG] Starting resourceSamlBypassUsersCreate")
+	usernames := convertStringSet(d.Get("usernames"))
+
+	log.Printf("[DEBUG] resourceSamlBypassUsersCreate Updated users list to send to API: %v", usernames)
+	err := saml.UpdateBypassUsers(c, usernames)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId("saml_bypass_users")
+	return resourceSamlBypassUsersRead(ctx, d, meta)
+}
+
+func resourceSamlBypassUsersRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+	log.Printf("[DEBUG] Starting resourceSamlBypassUsersRead")
+	usernames, err := saml.GetBypassUsers(c)
+	log.Printf("[DEBUG] resourceSamlBypassUsersRead user list from API: %v", usernames)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	if err := d.Set("usernames", usernames); err != nil {
+		return diag.FromErr(err)
+	}
+	return nil
+}
+
+func resourceSamlBypassUsersUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+	log.Printf("[DEBUG] Starting resourceSamlBypassUsersUpdate")
+	usernames := convertStringSet(d.Get("usernames"))
+	log.Printf("[DEBUG] resourceSamlBypassUsersUpdate Updated users list to send to API: %v", usernames)
+	err := saml.UpdateBypassUsers(c, usernames)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceSamlBypassUsersRead(ctx, d, meta)
+}
+
+func resourceSamlBypassUsersDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	c := meta.(*pc.Client)
+	log.Printf("[DEBUG] Starting resourceSamlBypassUsersDelete")
+
+	// To "delete" we set an empty list of usernames
+	err := saml.UpdateBypassUsers(c, []string{})
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// convertStringSet converts a *schema.Set to a []string
+func convertStringSet(set interface{}) []string {
+	result := make([]string, 0)
+	for _, v := range set.(*schema.Set).List() {
+		result = append(result, v.(string))
+	}
+	return result
+}

--- a/prismacloud/resource_saml_bypass_users_test.go
+++ b/prismacloud/resource_saml_bypass_users_test.go
@@ -1,0 +1,65 @@
+package prismacloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccResourceSamlBypassUsers(t *testing.T) {
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceSamlBypassUsersConfig("user1", "user2"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_users.test", "usernames.#", "2"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_users.test", "usernames.0", "user1"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_users.test", "usernames.1", "user2"),
+				),
+			},
+			{
+				Config: testAccResourceSamlBypassUsersConfig("user1", "user2", "user3"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_users.test", "usernames.#", "3"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_users.test", "usernames.0", "user1"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_users.test", "usernames.1", "user2"),
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_users.test", "usernames.2", "user3"),
+				),
+			},
+			{
+				Config: testAccResourceSamlBypassUsersConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("prismacloud_saml_bypass_users.test", "usernames.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceSamlBypassUsersConfig(usernames ...string) string {
+	config := `
+provider "prismacloud" {
+  # Provider configuration would go here
+}
+
+resource "prismacloud_saml_bypass_users" "test" {
+  usernames = [
+`
+
+	for i, username := range usernames {
+		config += `    "` + username + `"`
+		if i < len(usernames)-1 {
+			config += `,
+`
+		}
+	}
+
+	config += `
+  ]
+}
+`
+
+	return config
+}


### PR DESCRIPTION
# SAML Bypass Users Management

This pull request is entirely dependant on this one to update the go sdk: https://github.com/PaloAltoNetworks/prisma-cloud-go/pull/94

## Description

This pull request adds support for managing SAML bypass users in Prisma Cloud. 

### New Resources
1. **`prismacloud_saml_bypass_users`**: Manages the complete list of SAML bypass users by replacing the entire list
2. **`prismacloud_saml_bypass_subset_users`**: Manages a subset of SAML bypass users by adding/removing only specified users while preserving others managed outside of Terraform

### New Data Source
1. **`prismacloud_saml_bypass_users`**: Retrieves the current list of SAML bypass users from Prisma Cloud

## Motivation and Context

This feature addresses our need to manage SAML authentication bypass users in Prisma Cloud through Terraform. The implementation provides two approaches:

1. **Complete management**: For environments where Terraform should have full control over the SAML bypass user list
2. **Subset management**: For environments where Terraform needs to manage only specific users while allowing other users to be managed through other means (manual configuration, other automation tools, etc.)

This dual approach provides flexibility for different operational scenarios and prevents conflicts in environments with multiple management tools.

We started by implementing the first resource and data source, then added the subset management resource to provide more flexibility as it better suit our use case (see notes).

## How Has This Been Tested?

This has been tested in a production prisma environment as we do not have a sandbox environment.
First we shut down (commented out)  all PUT api requests in order to prevent any changes and checked the debug logs we implemented.
When all tests were ok we opened the PUT api calls and tested again.

Test procedure : 
For the datasource : 
- check the response of the datasource by adding its output to the terraform output

For the resource (prismacloud_saml_bypass_subset_users):
- Create a new resource with a list of users partially matching what is already in the bypass list
- Verify the users are added to the bypass list
- Update the resource and remove one user
- Verify the old users are removed 
- Destroy the resource and verify the users are removed from the bypass list while keeping unmanaged users

For the resource (prismacloud_saml_bypass_users):
- Create a new resource with a list of users
- Verify the users are added to the bypass list
- Update the resource and remove one user
- No destroy were tested as it would affect our prod environment

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly
- [x] I have read the **CONTRIBUTING** document
- [x] I have added tests to cover my changes (but could not run them as we do not have a testing environment)

## Notes

The subset resource is particularly valuable in environments where:
- Multiple teams manage different sets of bypass users (this is our use case)
- Some users are managed manually while others are managed via Terraform
