### PR TITLE
fix: isRetryableError parsing for 503/path format and replace PollApi…

### DIFF
--- a/prismacloud/poller.go
+++ b/prismacloud/poller.go
@@ -6,6 +6,7 @@ import (
 	pc "github.com/paloaltonetworks/prisma-cloud-go"
 	"log"
 	"math/rand"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -38,12 +39,28 @@ func PollApiUntilSuccessCustom(p Poller) diag.Diagnostics {
 }
 
 // isRetryableError checks if an error is retryable (429 Too Many Requests or 5xx Server Errors).
+// Handles multiple SDK error formats:
+//   - "503 error, and could not unmarshal header..." (unmarshal failure)
+//   - "503 error without the \"X-Redlock-Status\" header..." (missing header)
+//   - "503/path Error(msg:... severity:...)" (PrismaCloudErrorList format)
+//   - "429", "500", etc. (plain status codes)
 func isRetryableError(err error) bool {
 	if err == nil {
 		return false
 	}
 	errMsg := err.Error()
-	code := strings.Split(errMsg, " ")[0]
+
+	// Extract the status code from the error message.
+	// The first token may be "503" or "503/some/path", so split on "/" first
+	// to handle the PrismaCloudErrorList format (e.g., "503/compliance/...").
+	firstToken := strings.Split(errMsg, " ")[0]
+	code := strings.Split(firstToken, "/")[0]
+
+	// Validate that code is a number to avoid false positives
+	if _, parseErr := strconv.Atoi(code); parseErr != nil {
+		return false
+	}
+
 	switch code {
 	case "429", "500", "502", "503", "504":
 		return true

--- a/prismacloud/resource_policy.go
+++ b/prismacloud/resource_policy.go
@@ -737,20 +737,21 @@ func createPolicy(ctx context.Context, d *schema.ResourceData, meta interface{})
 		return diags
 	}
 
-	PollApiUntilSuccess(func() error {
-		_, err := policy.Identify(client, obj.Name)
+	var id string
+	if diags := RetryWithBackoff(client, func() error {
+		var err error
+		id, err = policy.Identify(client, obj.Name)
 		return err
-	})
-
-	id, err := policy.Identify(client, obj.Name)
-	if err != nil {
-		return diag.FromErr(err)
+	}); diags != nil {
+		return diags
 	}
 
-	PollApiUntilSuccess(func() error {
+	if diags := RetryWithBackoff(client, func() error {
 		_, err := policy.Get(client, id)
 		return err
-	})
+	}); diags != nil {
+		return diags
+	}
 
 	d.SetId(id)
 	return readPolicy(ctx, d, meta)


### PR DESCRIPTION
…UntilSuccess with RetryWithBackoff in createPolicy

- Fix isRetryableError() to handle PrismaCloudErrorList error format where error message starts with '503/path' instead of '503'. Split on '/' after space-split to extract numeric status code. Added strconv.Atoi validation to avoid false positives.

- Replace PollApiUntilSuccess (infinite loop) with RetryWithBackoff in createPolicy() for post-create verification calls (policy.Identify and policy.Get). This prevents infinite loops when proxy returns persistent 503 errors.


## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
